### PR TITLE
Match hero tagline width with title

### DIFF
--- a/script.js
+++ b/script.js
@@ -122,7 +122,25 @@
       t.classList.toggle('active', i === idx);
       if (i === idx) centre(t);                  // 🆕 centre on swipe
     });
-  });
+});
 
 })();                                   // ← last line (was just });)
+
+/* === HERO TAGLINE WIDTH MATCH ===================== */
+(function () {
+  const hero = document.querySelector('.hero');
+  if (!hero) return;
+  const heading = hero.querySelector('h1');
+  const tagline = hero.querySelector('.tagline');
+  if (!heading || !tagline) return;
+
+  function updateTaglineScale() {
+    const scale = heading.offsetWidth / tagline.offsetWidth;
+    tagline.style.setProperty('--tagline-scale', scale);
+  }
+
+  window.addEventListener('load', updateTaglineScale);
+  window.addEventListener('resize', updateTaglineScale);
+  updateTaglineScale();
+})();
 

--- a/style.css
+++ b/style.css
@@ -244,8 +244,11 @@ body {
   letter-spacing: 1px;
   font-weight: 400;
   margin-top: 0;
-  transform: translateY(-15%);
-  max-width: 90%;
+  display: inline-block;
+  width: auto;
+  max-width: none;
+  transform: translateY(-15%) scaleX(var(--tagline-scale, 1));
+  transform-origin: center top;
 }
 
 
@@ -369,7 +372,7 @@ header.scrolled {
     font-size: clamp(14px, 4vw, 18px);
     line-height: 1.4;
     font-style: italic;
-    max-width: 90%;
+    max-width: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust hero tagline styling to allow scaling
- add script to compute width scaling at runtime

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685158040c6483308d6ee52019fe9f5e