### PR TITLE
Fix tagline scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -246,7 +246,8 @@ body {
   display: inline-block;
   width: auto;
   max-width: none;
-  transform: translateY(-15%) scaleX(var(--tagline-scale, 1));
+  /* scale height along with width so the text isn't stretched */
+  transform: translateY(-15%) scale(var(--tagline-scale, 1));
   transform-origin: center top;
 }
 


### PR DESCRIPTION
## Summary
- scale hero tagline height so that its aspect ratio is consistent with the heading

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851618d63d08330a6e629d4300e103f