### PR TITLE
Improve carousel transition

### DIFF
--- a/script.js
+++ b/script.js
@@ -87,6 +87,21 @@
       spaceBetween: 20,
       speed: 500,
       slidesPerView: 1.35,           // desktop width
+      watchSlidesProgress: true,     // allow smooth scaling based on progress
+      on: {
+        progress(swiper) {
+          swiper.slides.forEach(slide => {
+            const p = Math.min(Math.abs(slide.progress), 1);
+            const scale = 0.90 + (1 - p) * 0.13; // 0.90 -> 1.03
+            slide.style.transform = `scale(${scale})`;
+          });
+        },
+        setTransition(swiper, speed) {
+          swiper.slides.forEach(slide => {
+            slide.style.transitionDuration = `${speed}ms`;
+          });
+        },
+      },
       breakpoints:{
         1200:{ slidesPerView: 2.6 },   // desktop / large laptop
         900:{ slidesPerView: 2.0 },   // tablet landscape
@@ -98,6 +113,8 @@
         prevEl: '.swiper-button-prev',
       },
     });
+    // ensure initial transforms are correct
+    processSwiper.emit('progress');
 
     /* pill ⇄ slide sync */
     const tabs = document.querySelectorAll('.process-tabs .tab');

--- a/style.css
+++ b/style.css
@@ -838,11 +838,9 @@ header.menu-open  .hamburger .line {
 .process-swiper .swiper-wrapper{overflow:visible!important;}
 
 .process-swiper .swiper-slide{
+  /* base transition for JS-driven scaling */
   transition:transform .5s ease;
 }
-
-.process-swiper .swiper-slide-active{transform:scale(1.03);}
-.process-swiper .swiper-slide:not(.swiper-slide-active){transform:scale(.90);}
 
 /* images fill slide */
 .process-swiper .swiper-slide img{


### PR DESCRIPTION
## Summary
- smooth the slide scale transition in the installation process carousel
- remove CSS that instantly scales slides and move scaling logic to JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685163ebf68c8330aae961a4074d14cb