### PR TITLE
Fix carousel autoplay and tabs

### DIFF
--- a/script.js
+++ b/script.js
@@ -103,8 +103,17 @@
   if (!sliderEl || tabs.length === 0 || typeof Swiper === 'undefined') return;
 
   const swiper = new Swiper(sliderEl, {
+    loop: true,
+    autoplay: {
+      delay: 3000,
+      disableOnInteraction: false,
+    },
     slidesPerView: 1,
     spaceBetween: 20,
+    breakpoints: {
+      768: { slidesPerView: 2 },
+      1024: { slidesPerView: 3 },
+    },
     navigation: {
       nextEl: '.swiper-button-next',
       prevEl: '.swiper-button-prev',
@@ -113,13 +122,13 @@
 
   tabs.forEach((tab, index) => {
     tab.addEventListener('click', () => {
-      swiper.slideTo(index);
+      swiper.slideToLoop(index);
     });
   });
 
   swiper.on('slideChange', () => {
     tabs.forEach(t => t.classList.remove('active'));
-    const idx = swiper.activeIndex;
+    const idx = swiper.realIndex;
     if (tabs[idx]) tabs[idx].classList.add('active');
   });
 })();

--- a/style.css
+++ b/style.css
@@ -774,6 +774,12 @@ header.menu-open  .hamburger .line {
   padding: 4px 8px;
 }
 .process-tabs .tab.active { color: var(--gold); }
+.process-swiper {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+.process-swiper .swiper-slide { text-align: center; }
 .process-swiper img { width: 100%; display: block; }
 .slide-title {
   margin: 8px 0 0;


### PR DESCRIPTION
## Summary
- improve Process carousel layout
- add Swiper autoplay, loop and 3-image view

## Testing
- `node -e "require('fs').readFileSync('script.js','utf8');console.log('parsed')"`

------
https://chatgpt.com/codex/tasks/task_e_68516da15e44833094ccb32d510bb5ab