### PR TITLE
Improve slide animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -104,6 +104,7 @@
 
   const swiper = new Swiper(sliderEl, {
     loop: true,
+    speed: 3000,
     autoplay: {
       delay: 3000,
       disableOnInteraction: false,


### PR DESCRIPTION
## Summary
- slow down carousel slide animation so manual navigation visibly moves over 3 seconds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851703854788330b4909bf97d0dfdfa