### PR TITLE
Improve slide animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -104,6 +104,7 @@
 
   const swiper = new Swiper(sliderEl, {
     loop: true,
+    speed: 3000,
     autoplay: {
       delay: 3000,
       disableOnInteraction: false,
@@ -122,7 +123,7 @@
 
   tabs.forEach((tab, index) => {
     tab.addEventListener('click', () => {
-      swiper.slideToLoop(index);
+      swiper.slideToLoop(index, 3000);
     });
   });
 

--- a/style.css
+++ b/style.css
@@ -779,6 +779,10 @@ header.menu-open  .hamburger .line {
   max-width: 1200px;
   margin: 0 auto;
 }
+.process-swiper .swiper-wrapper {
+  transition-property: transform;
+  transition-duration: 3s;
+}
 .process-swiper .swiper-slide { text-align: center; }
 .process-swiper img { width: 100%; display: block; }
 .slide-title {


### PR DESCRIPTION
## Summary
- slow down carousel slide animation so manual navigation visibly moves over 3 seconds

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851703854788330b4909bf97d0dfdfa