### PR TITLE
Fix next arrow for process carousel

### DIFF
--- a/script.js
+++ b/script.js
@@ -98,6 +98,12 @@
     },
   });
 
+  /* extra clicks to ensure navigation works on all setups */
+  const nextBtn = document.querySelector('.swiper-button-next');
+  const prevBtn = document.querySelector('.swiper-button-prev');
+  if (nextBtn) nextBtn.addEventListener('click', () => processSwiper.slideNext());
+  if (prevBtn) prevBtn.addEventListener('click', () => processSwiper.slidePrev());
+
   /* pill ⇄ slide sync */
   const tabs = document.querySelectorAll('.process-tabs .tab');
 

--- a/style.css
+++ b/style.css
@@ -812,6 +812,8 @@ header.menu-open  .hamburger .line {
   position:absolute;
   top:50%;
   transform:translateY(-50%);
+  cursor:pointer;
+  z-index:6; /* ensure buttons sit above slides */
 }
 .install-process .swiper-button-prev{left:100px;}
 .install-process .swiper-button-next{right:100px;}


### PR DESCRIPTION
## Summary
- ensure carousel arrows sit above slides and show pointer cursor
- add click listeners to next/prev buttons so right arrow advances slides

## Testing
- `node -e "console.log('no tests');"`

------
https://chatgpt.com/codex/tasks/task_e_685177e3afa48330a66819c92ab3e4ac