### PR TITLE
Add rotating text for process carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,13 @@
         <div class="swiper-button-next"></div>
       </div>
 
+      <!-- Rotating step copy -->
+      <div class="process-copy">
+        <p class="process-text active" data-step="0">Our expert team captures your space down to the millimetre, planning every detail from slab layout to fixture cut-outs for a clean, continuous look.</p>
+        <p class="process-text" data-step="1">Using Laminam slabs sourced from Modena, Italy, we custom-fabricate each panel in our 75,000 sq ft Monaghan facility.</p>
+        <p class="process-text" data-step="2">Precisely engineered slabs are installed quickly and seamlessly, creating a luxury, join-free finish that defines bespoke craftsmanship.</p>
+      </div>
+
 
       <!-- Carousel -->
       <div class="swiper process-swiper">

--- a/script.js
+++ b/script.js
@@ -106,6 +106,11 @@
 
   /* pill ⇄ slide sync */
   const tabs = document.querySelectorAll('.process-tabs .tab');
+  const texts = document.querySelectorAll('.process-text');
+
+  function updateCopy(index){
+    texts.forEach((t,i)=>{t.classList.toggle('active', i===index);});
+  }
 
   function centre(tab){                          // 🆕 helper
     const box = tab.parentElement;
@@ -119,6 +124,7 @@
       tab.classList.add('active');
       processSwiper.slideToLoop(i);
       centre(tab);                               // 🆕 centre on tap
+      updateCopy(i);
     });
   });
 
@@ -128,6 +134,7 @@
       t.classList.toggle('active', i === idx);
       if (i === idx) centre(t);                  // 🆕 centre on swipe
     });
+    updateCopy(idx);
   });
 
 })();                                   // ← last line (was just });)

--- a/style.css
+++ b/style.css
@@ -805,6 +805,15 @@ header.menu-open  .hamburger .line {
   color:#fff;
 }
 
+/* rotating step copy */
+.process-copy{
+  max-width:640px;
+  margin:0 auto 40px;
+  text-align:center;
+}
+.process-text{display:none;}
+.process-text.active{display:block;}
+
 /* arrow buttons */
 .install-process .swiper-button-prev,
 .install-process .swiper-button-next{


### PR DESCRIPTION
## Summary
- show installation text beneath process tabs
- style the rotating copy to match layout
- sync text with tabs and swiper slides

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68517d90e6e08330beed52a4a89d180e