### PR TITLE
Adjust hero height to include padding

### DIFF
--- a/style.css
+++ b/style.css
@@ -196,6 +196,7 @@ section:last-of-type {
   background: url('images/arabescato-gold-laminam.png') no-repeat center center/cover;
   text-align: center;
   height: 100vh;
+  box-sizing: border-box; /* include padding in height */
   padding: 80px 40px 120px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- keep the hero at exactly the viewport height by including padding in the box model

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68517e14dd5c8330bda7fe767d66b12c