### PR TITLE
Adjust process tabs spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -785,7 +785,7 @@ header.menu-open  .hamburger .line {
   justify-content:center;
   flex-wrap:wrap;
   gap:16px;
-  margin-bottom:60px;
+  margin-bottom:0;           /* tighter height */
 }
 .process-tabs .tab{
   font-family:'Work Sans',sans-serif;
@@ -818,8 +818,8 @@ header.menu-open  .hamburger .line {
 /* arrow buttons */
 .install-process .swiper-button-prev,
 .install-process .swiper-button-next{
-  width:44px;
-  height:44px;
+  width:36px;
+  height:36px;               /* match pill height */
   border-radius:50%;
   border:1px solid #ccc;
   background:#fff;
@@ -870,7 +870,7 @@ header.menu-open  .hamburger .line {
   justify-content:center;
   align-items:center;
   gap:24px;        /* space between arrow ↔ tabs */
-  margin-bottom:60px;
+  margin-bottom:40px;      /* less empty space */
 }
 
 /* ─── INSTALLATION-PROCESS ▸ arrow position ─────────────────────────── */
@@ -882,8 +882,8 @@ header.menu-open  .hamburger .line {
   .install-process .swiper-button-next{
     position:absolute;
     top:160px;              /* ≈ vertical centre of pill-tabs line */
-    width:44px;
-    height:44px;
+    width:36px;
+    height:36px;
     border-radius:50%;
     border:1px solid #ccc;
     background:#fff;


### PR DESCRIPTION
## Summary
- reduce margin under `.process-tabs`
- shrink previous/next arrow controls to match pill height
- use smaller bottom margin for the tabs wrapper

## Testing
- `grep -n "width:36px" -n style.css`


------
https://chatgpt.com/codex/tasks/task_e_6851816d683c8330a5ad35cae0f6631e