### PR TITLE
Fix hero tagline color and scaling

### DIFF
--- a/hero/script.js
+++ b/hero/script.js
@@ -27,3 +27,7 @@ function scaleTaglineToMatchHeadline() {
   // Step 3: apply scaled size
   tagline.style.fontSize = `${newSize}px`;
 }
+
+window.addEventListener('load', scaleTaglineToMatchHeadline);
+window.addEventListener('resize', scaleTaglineToMatchHeadline);
+

--- a/hero/style.css
+++ b/hero/style.css
@@ -12,8 +12,10 @@
 .hero-inner {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-end;
   height: 100vh;
+  padding-bottom: 25vh;
+  position: relative;
 }
 
 .hero-block {
@@ -41,4 +43,5 @@
   text-align: center;
   margin-top: 0.8rem;
   padding: 0;
+  color: var(--color-gold);
 }


### PR DESCRIPTION
## Summary
- ensure hero text sits in the lower quarter of the viewport
- color the hero tagline gold
- automatically scale tagline width on load and resize

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6852b4ac816c83309df9943cfb6a5d6b