### PR TITLE
Center about button on mobile

### DIFF
--- a/about/about.html
+++ b/about/about.html
@@ -6,7 +6,7 @@
         At Sabre Stone Commercial, we specialise in the design, fabrication, and installation of bespoke stone solutions for commercial and residential spaces. Operating from our 75,000 sq ft facility in County Monaghan, we serve architects, developers, and designers across the UK and Ireland with custom-crafted surfaces that unite technical excellence with refined aesthetics. From large-format porcelain wall cladding to tailored furniture and worktops, our work is defined by precision, durability, and material integrity. Every project is a collaboration — shaped by vision, delivered with craftsmanship, and built to endure.
       </p>
         <a href="#" class="btn btn--pill">
-        <span class="btn-text">Learn More</span>
+        <span class="btn-text">About Us</span>
         <span class="btn-dot"></span>
         </a>
     </div>

--- a/about/style.css
+++ b/about/style.css
@@ -51,8 +51,8 @@
     text-align: center;
   }
 
-    .text-block a.btn {
-    margin: 0;
-    justify-content: flex-start;
-    }
+  .text-block a.btn {
+    margin: 0 auto;
+    justify-content: center;
+  }
 }


### PR DESCRIPTION
## Summary
- tweak About Us button text
- center the about page button for mobile screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852efa1e5908330952f6f4abe866ddd