### PR TITLE
Improve applications slider spacing

### DIFF
--- a/applications/script.js
+++ b/applications/script.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const swiper = new Swiper('.applications-slider', {
     loop: true,
     centeredSlides: true,
-    spaceBetween: 20,
+    spaceBetween: 0,
     slidesPerView: 3,          // always aim for three at desktop
     breakpoints: {             // responsive counts (side slides peek)
       0:   { slidesPerView: 1.2 },

--- a/applications/style.css
+++ b/applications/style.css
@@ -47,7 +47,11 @@
 }
 
 /* === APPLICATIONS SLIDER — full-bleed, 3 visible ====================== */
-:root { --slide-gap: 0px; }          /* gap between frames (0 = flush)    */
+:root { --slide-gap: 0px; }          /* default gap for mobile */
+
+@media (min-width:1020px){           /* desktop spacing */
+  :root { --slide-gap: 40px; }
+}
 
 .applications-slider {               /* slider wrapper (outside container)*/
   width: 100%;
@@ -60,7 +64,8 @@
 
 /* each frame = exactly 1/3 viewport, no side gut- ters  */
 .applications-slider .swiper-slide{
-  width: calc(100vw / 3);
+  width: calc((100vw - var(--slide-gap) * 6) / 3);
+  margin: 0 var(--slide-gap);
   position: relative;
   overflow: hidden;
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- introduce desktop-only `--slide-gap` spacing for applications gallery
- widen slide rule to account for desktop gap
- remove Swiper `spaceBetween` and keep default centering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a931add80833090bc27374adc5a9b