### PR TITLE
Restyle Applications category tabs

### DIFF
--- a/applications/applications.html
+++ b/applications/applications.html
@@ -14,12 +14,12 @@
 
     <div class="frames__controls">
       <div class="pill-container">
-        <nav class="nav-pills">
-          <button class="btn btn--tab app-category active" data-target="0">WALL CLADDING</button>
-          <button class="btn btn--tab app-category" data-target="1">KITCHEN WORKTOPS</button>
-          <button class="btn btn--tab app-category" data-target="2">BESPOKE TABLES</button>
-          <button class="btn btn--tab app-category" data-target="3">WASHBASINS &amp; VANITY TOPS</button>
-          <button class="btn btn--tab app-category" data-target="4">RECEPTION DESKS &amp; COUNTERS</button>
+        <nav class="nav-pills tabs--applications u-flex-center">
+          <button class="btn btn--text app-category active" data-target="0">WALL CLADDING</button>
+          <button class="btn btn--text app-category" data-target="1">KITCHEN WORKTOPS</button>
+          <button class="btn btn--text app-category" data-target="2">BESPOKE TABLES</button>
+          <button class="btn btn--text app-category" data-target="3">WASHBASINS &amp; VANITY TOPS</button>
+          <button class="btn btn--text app-category" data-target="4">RECEPTION DESKS &amp; COUNTERS</button>
         </nav>
       </div>
     </div>

--- a/applications/style.css
+++ b/applications/style.css
@@ -17,20 +17,14 @@
 }
 
 .nav-pills {
-  display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
   gap: 10px;
   padding-bottom: 10px;
-  justify-content: flex-start;
   scroll-snap-type: x mandatory;
   -webkit-overflow-scrolling: touch;
 }
 
-.btn--tab {
-  scroll-snap-align: center;
-  flex-shrink: 0;
-}
 
 .frames__title {
   margin-bottom: 40px;

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
   </script>
 
   <script>
-    const activeTab = document.querySelector('.btn--tab.active');
+    const activeTab = document.querySelector('.app-category.active');
     if (activeTab) {
       activeTab.scrollIntoView({ inline: 'center', behavior: 'smooth' });
     }

--- a/style/buttons.css
+++ b/style/buttons.css
@@ -98,3 +98,16 @@
   border-radius: 50% !important;
   margin-left: 8px !important;
 }
+
+/* Text-only buttons reused for tabs and links */
+.btn--text {
+  padding: 0;
+  background: none;
+  border: none;
+  font-family: var(--font-serif-heading);
+  color: var(--brand-blue);
+}
+
+.btn--text.active {
+  text-decoration: underline;
+}

--- a/style/layout.css
+++ b/style/layout.css
@@ -1,0 +1,9 @@
+:root {}
+
+/* Utility flex helpers */
+.u-flex-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+

--- a/style/variables.css
+++ b/style/variables.css
@@ -1,0 +1,6 @@
+:root {
+  /* Brand tokens reused across components */
+  --brand-blue: var(--color-blue);
+  --font-serif-heading: var(--font-heading);
+}
+


### PR DESCRIPTION
## Summary
- add brand tokens in `variables.css`
- add flex helper to `layout.css`
- add text button variant in `buttons.css`
- simplify applications tabs markup and styles
- adjust script selector for active tab

## Testing
- `npm test` *(fails: Could not find package.json)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_685a9b6789148330a0dd2d53c94f12c3