### PR TITLE
Fix application tabs overflow

### DIFF
--- a/style/buttons.css
+++ b/style/buttons.css
@@ -101,6 +101,7 @@
 
 /* Text-only buttons reused for tabs and links */
 .btn--text {
+  display: inline-block; /* keep gaps consistent */
   padding: 0;
   background: none;
   border: none;

--- a/style/layout.css
+++ b/style/layout.css
@@ -7,3 +7,36 @@
   align-items: center;
 }
 
+/* Utility to visually hide native scrollbars */
+.u-hide-scrollbar {
+  -ms-overflow-style: none; /* IE & Edge */
+  scrollbar-width: none;    /* Firefox */
+}
+.u-hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+/* Applications category tabs container */
+.tabs--applications {
+  flex-wrap: nowrap;               /* keep in one line */
+  overflow-x: auto;                /* sideways scroll if needed */
+  gap: var(--space-xs);            /* spacing token */
+  white-space: nowrap;             /* prevent wrapping */
+  -webkit-overflow-scrolling: touch; /* smooth iOS scroll */
+}
+.tabs--applications {
+  /* hide scrollbars when overflowing */
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.tabs--applications::-webkit-scrollbar {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .tabs--applications {
+    flex-wrap: wrap;              /* allow wrapping on larger screens */
+    gap: var(--space-sm);         /* slightly larger gap */
+  }
+}
+


### PR DESCRIPTION
## Summary
- tweak `.btn--text` to render as inline-block
- hide scrollbars and add mobile overflow styles for `.tabs--applications`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a9dcb0ba4833093610db32db7561b