### PR TITLE
Add load more option to card grids

### DIFF
--- a/porcelain-marble.html
+++ b/porcelain-marble.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="sections/cta-banner/style.css">
   <link rel="stylesheet" href="sections/page-title/style.css">
   <link rel="stylesheet" href="sections/card-grid/style.css">
+  <script src="sections/card-grid/script.js" defer></script>
 
   <!-- Logo preload -->
   <link rel="preload" href="images/symbol-blue.svg" as="image" />

--- a/projects.html
+++ b/projects.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="sections/cta-banner/style.css">
   <link rel="stylesheet" href="sections/page-title/style.css">
   <link rel="stylesheet" href="sections/card-grid/style.css" />
+  <script src="sections/card-grid/script.js" defer></script>
 
   <!-- Logo preload -->
   <link rel="preload" href="images/symbol-blue.svg" as="image" />

--- a/sections/card-grid/script.js
+++ b/sections/card-grid/script.js
@@ -1,0 +1,19 @@
+// Show up to THRESHOLD cards initially and reveal more on demand
+(function(){
+  const THRESHOLD = 18;
+  document.querySelectorAll('.card-grid').forEach(grid => {
+    const cards = grid.querySelectorAll('.card');
+    if (cards.length <= THRESHOLD) return;
+    cards.forEach((card, idx) => {
+      if (idx >= THRESHOLD) card.classList.add('card--hidden');
+    });
+    const btn = document.createElement('button');
+    btn.className = 'btn btn--outline card-grid__load-more';
+    btn.textContent = 'Load More';
+    btn.addEventListener('click', () => {
+      grid.querySelectorAll('.card--hidden').forEach(c => c.classList.remove('card--hidden'));
+      btn.remove();
+    });
+    grid.parentNode.insertBefore(btn, grid.nextSibling);
+  });
+})();

--- a/sections/card-grid/style.css
+++ b/sections/card-grid/style.css
@@ -130,3 +130,13 @@
     flex: 0 0 calc((100% - 100px) / 6);
   }
 }
+
+/* Load more button */
+.card-grid__load-more {
+  display: block;
+  margin: 20px auto;
+}
+
+.card--hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- introduce card-grid/script.js to hide excess cards
- style and hide hidden cards
- load script on Projects and Porcelain Marble pages

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685fc293b13483308352446241b96a60