### PR TITLE
Fix avatar color on contact page

### DIFF
--- a/sections/contact-trio/style.css
+++ b/sections/contact-trio/style.css
@@ -33,7 +33,7 @@
   aspect-ratio: 3/4;
   background: linear-gradient(to bottom,
               transparent 0 20%,
-              var(--color-blue) 20% 100%);
+              var(--color-navy) 20% 100%);
   margin-bottom: 16px;
   overflow: hidden;
 }


### PR DESCRIPTION
## Summary
- use the dark navy variable for the avatar backgrounds on the contact page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6863ce9763948330b9487ce707112178