### PR TITLE
Fix cookie banner persistence

### DIFF
--- a/about.html
+++ b/about.html
@@ -276,23 +276,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/contact.html
+++ b/contact.html
@@ -283,23 +283,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/cookies-policy.html
+++ b/cookies-policy.html
@@ -114,23 +114,23 @@
   </script>
 
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -411,23 +411,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/porcelain-marble.html
+++ b/porcelain-marble.html
@@ -547,23 +547,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/porcelain-metal.html
+++ b/porcelain-metal.html
@@ -263,23 +263,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/porcelain-solid-colours.html
+++ b/porcelain-solid-colours.html
@@ -238,23 +238,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/porcelain-stone.html
+++ b/porcelain-stone.html
@@ -420,23 +420,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/porcelain-texture.html
+++ b/porcelain-texture.html
@@ -273,23 +273,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/porcelain-wood.html
+++ b/porcelain-wood.html
@@ -215,23 +215,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -144,23 +144,23 @@
   </script>
 
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 </body>

--- a/product-range.html
+++ b/product-range.html
@@ -406,23 +406,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/projects.html
+++ b/projects.html
@@ -315,23 +315,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 

--- a/sections/cookies/style.css
+++ b/sections/cookies/style.css
@@ -1,5 +1,6 @@
 .cookie-banner {
-	position: fixed;
+        display: none;
+        position: fixed;
 	bottom: 0;
 	left: 0;
 	right: 0;

--- a/terms.html
+++ b/terms.html
@@ -132,23 +132,23 @@
   </script>
 
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 </body>

--- a/wall-cladding.html
+++ b/wall-cladding.html
@@ -267,23 +267,23 @@
 
   
   <script>
-  fetch('sections/cookies/cookies.html')
-    .then(res => res.text())
-    .then(html => {
-      document.body.insertAdjacentHTML('beforeend', html);
+  if (!localStorage.getItem('cookiesAccepted')) {
+    fetch('sections/cookies/cookies.html')
+      .then(res => res.text())
+      .then(html => {
+        document.body.insertAdjacentHTML('beforeend', html);
 
-      const banner = document.getElementById('cookie-banner');
-      const acceptBtn = document.getElementById('accept-cookies');
+        const banner = document.getElementById('cookie-banner');
+        const acceptBtn = document.getElementById('accept-cookies');
 
-      if (!localStorage.getItem('cookiesAccepted')) {
         banner.style.display = 'block';
-      }
 
-      acceptBtn.addEventListener('click', () => {
-        localStorage.setItem('cookiesAccepted', 'true');
-        banner.style.display = 'none';
+        acceptBtn.addEventListener('click', () => {
+          localStorage.setItem('cookiesAccepted', 'true');
+          banner.style.display = 'none';
+        });
       });
-    });
+  }
   </script>
 
 


### PR DESCRIPTION
## Summary
- hide cookie banner by default and check localStorage before fetching
- only load banner if cookies weren't already accepted

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_68643beb436083309af13a1589a84cb1