### PR TITLE
Fix porcelain page logo preload paths

### DIFF
--- a/porcelain-metal.html
+++ b/porcelain-metal.html
@@ -43,8 +43,8 @@
   <link rel="stylesheet" href="sections/cookies/style.css" />
   
   <!-- Logo preload -->
-  <link rel="preload" href="images/porcelain-colours/symbol-blue.svg" as="image" />
-  <link rel="preload" href="images/porcelain-colours/symbol-white.svg" as="image" />
+  <link rel="preload" href="images/symbol-blue.svg" as="image" />
+  <link rel="preload" href="images/symbol-white.svg" as="image" />
 
     <!-- Swiper bundle (CSS + JS) -->
   <link rel="stylesheet"

--- a/porcelain-solid-colours.html
+++ b/porcelain-solid-colours.html
@@ -43,8 +43,8 @@
   <link rel="stylesheet" href="sections/cookies/style.css" />
   
   <!-- Logo preload -->
-  <link rel="preload" href="images/porcelain-colours/symbol-blue.svg" as="image" />
-  <link rel="preload" href="images/porcelain-colours/symbol-white.svg" as="image" />
+  <link rel="preload" href="images/symbol-blue.svg" as="image" />
+  <link rel="preload" href="images/symbol-white.svg" as="image" />
 
     <!-- Swiper bundle (CSS + JS) -->
   <link rel="stylesheet"

--- a/porcelain-stone.html
+++ b/porcelain-stone.html
@@ -43,8 +43,8 @@
   <link rel="stylesheet" href="sections/cookies/style.css" />
 
   <!-- Logo preload -->
-  <link rel="preload" href="images/porcelain-colours/symbol-blue.svg" as="image" />
-  <link rel="preload" href="images/porcelain-colours/symbol-white.svg" as="image" />
+  <link rel="preload" href="images/symbol-blue.svg" as="image" />
+  <link rel="preload" href="images/symbol-white.svg" as="image" />
 
     <!-- Swiper bundle (CSS + JS) -->
   <link rel="stylesheet"

--- a/porcelain-texture.html
+++ b/porcelain-texture.html
@@ -43,8 +43,8 @@
   <link rel="stylesheet" href="sections/cookies/style.css" />
 
   <!-- Logo preload -->
-  <link rel="preload" href="images/porcelain-colours/symbol-blue.svg" as="image" />
-  <link rel="preload" href="images/porcelain-colours/symbol-white.svg" as="image" />
+  <link rel="preload" href="images/symbol-blue.svg" as="image" />
+  <link rel="preload" href="images/symbol-white.svg" as="image" />
 
     <!-- Swiper bundle (CSS + JS) -->
   <link rel="stylesheet"

--- a/porcelain-wood.html
+++ b/porcelain-wood.html
@@ -43,8 +43,8 @@
   <link rel="stylesheet" href="sections/cookies/style.css" />
   
   <!-- Logo preload -->
-  <link rel="preload" href="images/porcelain-colours/symbol-blue.svg" as="image" />
-  <link rel="preload" href="images/porcelain-colours/symbol-white.svg" as="image" />
+  <link rel="preload" href="images/symbol-blue.svg" as="image" />
+  <link rel="preload" href="images/symbol-white.svg" as="image" />
 
     <!-- Swiper bundle (CSS + JS) -->
   <link rel="stylesheet"


### PR DESCRIPTION
## Summary
- fix broken logo preloads on all porcelain finish pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68644c6e8e8083308fb387d8d1c0231c