### PR TITLE
style: align trade banner text styles

### DIFF
--- a/trade.html
+++ b/trade.html
@@ -31,9 +31,9 @@
   <!-- Page masthead -->
   <section class="intro-banner">
     <div class="intro-banner__content">
-      <h1>For Builders, Designers &amp; Architects</h1>
-      <div class="intro-banner__text-block">
-        <p class="text-muted">A reliable partner for precision joinery and high end residential projects.</p>
+      <h1 class="fade-in">For Builders, Designers &amp; Architects</h1>
+      <div class="intro-banner__text-block fade-in">
+        <p class="subheading">A reliable partner for precision joinery and high end residential projects.</p>
         <p>
           Cove Bespoke works with trade professionals who need a focused workshop and clear communication from the first briefing to final installation. There is no showroom and no sales team. You work directly with the maker who designs, builds, finishes, and installs.
         </p>


### PR DESCRIPTION
## Summary
- restyle trade page intro banner heading and subtitle to match other pages

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f2cb505308330a78130d10cc98c0d